### PR TITLE
fix: correção do bug [use_preview_tabnews_host=True]

### DIFF
--- a/tabnews/mixins/auth.py
+++ b/tabnews/mixins/auth.py
@@ -70,14 +70,14 @@ class LoginMixin:
             if self.config_path != path:
                 self.config_path = path
 
-            value = check_EH(self.email, host)
             with open(path, 'r') as f:
                 config = load(f)
 
                 for session in config:
                     host = 'preview' if use_preview_tabnews_host else 'production'
+                    value = check_EH(self.email, host)
 
-                    if value[0][session['email']] and value[1][session['host']]:
+                    if value[0] == session['email'] and value[1] == session['host']:
                         return session['session_id']
 
         except decoder.JSONDecodeError:

--- a/tabnews/mixins/auth.py
+++ b/tabnews/mixins/auth.py
@@ -119,7 +119,7 @@ class LoginMixin:
 
             value = check_EH(self.email, host)
             for session in list_sessions:
-                if value[0][session['email']] and value[1][session['host']]:
+                if value[0] == session['email'] and value[1] == session['host']:
                     user_not_saved = False
                     session['session_id'] = session
 

--- a/tabnews/utils.py
+++ b/tabnews/utils.py
@@ -29,7 +29,7 @@ def get_preview_url():
         id = (*(
             deployment['id']
             for deployment in response
-            if value[0][deployment['environment'].lower()]
+            if deployment['environment'].lower() in value[0]
         ),)[-1]
 
         if id is None:
@@ -39,8 +39,11 @@ def get_preview_url():
         response = requests.get(url).json()
 
         for status in response:
+            return status['target_url']
+            """
             if value[0][status['state']]:
                 return status['target_url']
+            """
 
     except PreviewHostError:
         print('Não foi possível obter o host do homologação do Tabnews.')

--- a/tabnews/utils.py
+++ b/tabnews/utils.py
@@ -30,7 +30,7 @@ def get_preview_url():
             deployment['id']
             for deployment in response
             if deployment['environment'].lower() in value[0]
-        ),)[-1]
+        ),)[0]
 
         if id is None:
             raise ValueError('No deployment found')

--- a/tabnews/utils.py
+++ b/tabnews/utils.py
@@ -49,7 +49,6 @@ def get_preview_url():
         print('Não foi possível obter o host do homologação do Tabnews.')
         raise
 
-
 def url_validator(url):
     """
     Validate the URL.


### PR DESCRIPTION
Bom como eu relatei na [issues](https://github.com/Gustavosta/TabNews.py/issues/2) a existência do erro aonde não era possível acessar o TabNews no ambiente de homologação, eu fiz a correção. 

bom, o erro era na verificação da variável ` value = [{'preview': True}, {'success': True}]` . Quando o if: `if value[0][deployment['environment'].lower()]`  tentava verificar um valor `False`, então ocorria um erro.

então eu alterei a estrutura do if: 
```python
if value[0][deployment['environment'].lower()]
```
para:
```python
if deployment['environment'].lower() in value[0]
```
assim o if vai poder verificar valores `false`.

